### PR TITLE
[FIX] gui: 인코딩된 url이 인식 안 되던 문제 수정

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1,8 +1,10 @@
 import tkinter as tk
 import urllib.request
+import urllib.parse
 from tts import speak_caption
 from PIL import Image, ImageTk
 from translator import translate_caption
+from urllib.parse import urlsplit, urlunsplit, quote
 
 frame = tk.Tk()
 frame.title("눈뜬송이")
@@ -13,17 +15,23 @@ label = tk.Label(frame)
 #URL 입력받기
 urlLabel = tk.Label(frame, text="이미지 URL 입력", font=("맑은 고딕", 12))
 urldown = tk.Button(frame, text="시작", command=lambda: download_image())
-urlinput = tk.Text(frame, height=1, width=100)
+urlinput = tk.Text(frame, height=2, width=100)
+
+
+#한글 포함된 URL 처리
+def url_encode(u):
+    parts = urlsplit(u)
+    path = quote(parts.path)
+    return urlunsplit((parts.scheme, parts.netloc, path, parts.query, parts.fragment))
 
 
 #URL 이미지 로컬에 다운로드
 def download_image():
-    url = urlinput.get("1.0", tk.END).strip()
+    K_url = urlinput.get("1.0", tk.END).strip()
     save = "image.png"
 
-    #한글 포함된 URL 처리
-    url = urllib.parse.quote(url, safe=':/?&=')
-    #print(url)
+    url = url_encode(K_url)
+    print(K_url)
 
     try:
         with urllib.request.urlopen(url) as response:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #issue

#10

<br/>

## 💻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

인코딩된 url을 인식하지 못하던 버그를 수정했습니다!
<br/>

### 스크린샷 (선택)

사용 url: https://media.istockphoto.com/id/2042539861/ko/%EC%82%AC%EC%A7%84/%ED%9C%B4%EA%B0%80-%EC%A4%91-%EC%85%80%EC%B9%B4%EB%A5%BC-%EC%B0%8D%EB%8A%94-%EC%A6%90%EA%B1%B0%EC%9A%B4-%EC%B9%9C%EA%B5%AC%EB%93%A4.jpg?s=612x612&w=0&k=20&c=RZAjDCGUsUCGlP3yEhdFKQvYoz3VyiMGv9EFRLE73bY=
![스크린샷 2025-06-16 112140](https://github.com/user-attachments/assets/d469d5c9-b6e4-43a7-afed-d6b2fc95aeb2)

<br/>

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
ex) 메서드 xxx의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

확인 결과 일부 사이트의 이미지는 사이트의 정책 탓에 연결이 거부되는 것으로 확인되었습니다...!
istock 사이트가 가장 안정적으로 연결됩니다. 참고해주세요!!
사이트 주소: https://www.istockphoto.com/kr
